### PR TITLE
Fix field value ordering in FieldsMapOfSliceOfAny

### DIFF
--- a/serr.go
+++ b/serr.go
@@ -124,7 +124,7 @@ func (se SErr) FieldsMapOfSliceOfAny() map[string][]any {
 			key = fmt.Sprintf("%v", val)
 		} else {
 			if origArr, ok := flds[key]; ok { // key is already in the map
-				flds[key] = append(origArr, val)
+				flds[key] = append([]any{val}, origArr...)
 			} else {
 				flds[key] = []any{val}
 			}

--- a/serr_test.go
+++ b/serr_test.go
@@ -12,7 +12,7 @@ func TestSErrFromatting(t *testing.T) {
 	ser2 := WrapAsSErr(ser, "att2", "valNew")
 	ser3 := WrapAsSErr(ser2, "att2", "valNewer")
 
-	const expected = "att2[val2 -> valNew -> valNewer]"
+	const expected = "att2[valNewer -> valNew -> val2]"
 
 	result := ser3.FieldsAsCustomString(", ", " -> ")
 	if !strings.Contains(result, expected) {


### PR DESCRIPTION
## Summary
Fixed the order of field values in `FieldsMapOfSliceOfAny()` to maintain chronological order (newest first) when multiple values are added to the same field key.

## Changes
- **serr.go**: Modified the append logic in `FieldsMapOfSliceOfAny()` to prepend new values instead of appending them, ensuring the most recently added value appears first in the slice
- **serr_test.go**: Updated the expected output in `TestSErrFromatting` to reflect the corrected ordering where values appear in reverse chronological order (valNewer -> valNew -> val2)

## Implementation Details
The fix changes `append(origArr, val)` to `append([]any{val}, origArr...)`, which prepends the new value to the existing slice. This ensures that when wrapping errors multiple times with the same field key, the values are ordered from newest to oldest, providing a more intuitive representation of the error chain.

https://claude.ai/code/session_01QqucuBhA8rtzoyz2nQ7xie